### PR TITLE
Fix edge case in server selection when node pool names were overlapping

### DIFF
--- a/cluster-autoscaler/cloudprovider/gridscale/README.md
+++ b/cluster-autoscaler/cloudprovider/gridscale/README.md
@@ -137,15 +137,26 @@ Modify the following `Tiltfile` to rebuild and deploy the container image into a
    1. Replace `<your-test-project>` with an actual project at `https://registry.kubecuddle.io`
    2. Replace `gsk-v1.31.2` with the version used in `cluster-autoscaler-autodiscover.yaml`
 4. Run `tilt up` to start Tilt
-5. Manually build the Go binary whenever you want to update the deployment: `make build-arch-amd64`
+5. Open Tilt in your browser and build the binary by clicking on the `binary` resource. Do this every time you change the Go code.
 
 ```Tiltfile
-watch_file("cluster-autoscaler-amd64")
+local_resource(
+  "binary",
+  cmd="make build-arch-amd64",
+  trigger_mode=TRIGGER_MODE_MANUAL,
+  auto_init=False,
+  labels=["makefile"],
+  deps = ["."]
+)
 
 docker_build(
     ref = "registry.kubecuddle.io/<your-test-project>/cluster-autoscaler:gsk-v1.31.2",
     context = ".",
     dockerfile = "Dockerfile.amd64",
+    only = [
+        "Dockerfile.amd64",
+        "cluster-autoscaler-amd64",
+    ]
 )
 
 k8s_yaml('cluster-autoscaler-autodiscover.namespace.yaml')

--- a/cluster-autoscaler/cloudprovider/gridscale/gridscale_node_group.go
+++ b/cluster-autoscaler/cloudprovider/gridscale/gridscale_node_group.go
@@ -256,26 +256,34 @@ func (n *NodeGroup) Nodes() ([]cloudprovider.Instance, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	var gskNodeList []gsclient.Server
-SERVERLISTLOOP:
 	for _, server := range serverList {
-		// skip master node
-		if strings.Contains(server.Properties.Name, "master") {
-			continue
-		}
-		// append nodes that have the label
-		// #gsk#<clusterUUID> and names have the node group name in it
-		for _, label := range server.Properties.Labels {
-			if label == fmt.Sprintf("#gsk#%s", n.clusterUUID) &&
-				strings.Contains(server.Properties.Name, n.name) {
-				gskNodeList = append(gskNodeList, server)
-				continue SERVERLISTLOOP
-			}
+		if n.doesNodeMatch(server) {
+			gskNodeList = append(gskNodeList, server)
 		}
 	}
 	nodeList := toInstances(gskNodeList)
-	klog.V(4).Infof("Node list: %v ", nodeList)
+
+	klog.V(4).Infof("Node list for node group %v: %v ", n.name, nodeList)
 	return nodeList, nil
+}
+
+func (n *NodeGroup) doesNodeMatch(server gsclient.Server) bool {
+	// skip master node
+	if strings.Contains(server.Properties.Name, "master") {
+		return false
+	}
+
+	// append nodes that have the label
+	// #gsk#<clusterUUID> and names have the node group name in it
+	for _, label := range server.Properties.Labels {
+		if label == fmt.Sprintf("#gsk#%s", n.clusterUUID) && strings.Contains(server.Properties.Name, n.name) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // TemplateNodeInfo returns a schedulerframework.NodeInfo structure of an empty

--- a/cluster-autoscaler/cloudprovider/gridscale/gridscale_node_group.go
+++ b/cluster-autoscaler/cloudprovider/gridscale/gridscale_node_group.go
@@ -275,12 +275,23 @@ func (n *NodeGroup) doesNodeMatch(server gsclient.Server) bool {
 		return false
 	}
 
-	// append nodes that have the label
-	// #gsk#<clusterUUID> and names have the node group name in it
+	// write server labels into a map for easier lookup
+	labelMap := make(map[string]struct{}, len(server.Properties.Labels))
+
 	for _, label := range server.Properties.Labels {
-		if label == fmt.Sprintf("#gsk#%s", n.clusterUUID) && strings.Contains(server.Properties.Name, n.name) {
-			return true
-		}
+		labelMap[label] = struct{}{}
+	}
+
+	// Build expected labels which relate the server to this node group
+	expectedClusterLabel := fmt.Sprintf("#gsk#%s", n.clusterUUID)
+
+	// skip nodes not belonging to this cluster
+	if _, found := labelMap[expectedClusterLabel]; !found {
+		return false
+	}
+	// keep nodes whose name indicates they belong to this node group
+	if strings.Contains(server.Properties.Name, n.name) {
+		return true
 	}
 
 	return false

--- a/cluster-autoscaler/cloudprovider/gridscale/gridscale_node_group.go
+++ b/cluster-autoscaler/cloudprovider/gridscale/gridscale_node_group.go
@@ -278,20 +278,39 @@ func (n *NodeGroup) doesNodeMatch(server gsclient.Server) bool {
 	// write server labels into a map for easier lookup
 	labelMap := make(map[string]struct{}, len(server.Properties.Labels))
 
+	containsPoolLabel := false
+
 	for _, label := range server.Properties.Labels {
 		labelMap[label] = struct{}{}
+
+		if strings.HasPrefix(label, "#gsk-pool#") {
+			containsPoolLabel = true
+		}
 	}
 
 	// Build expected labels which relate the server to this node group
 	expectedClusterLabel := fmt.Sprintf("#gsk#%s", n.clusterUUID)
+	expectedPoolLabel := fmt.Sprintf("#gsk-pool#%s", n.name)
 
 	// skip nodes not belonging to this cluster
 	if _, found := labelMap[expectedClusterLabel]; !found {
 		return false
 	}
-	// keep nodes whose name indicates they belong to this node group
-	if strings.Contains(server.Properties.Name, n.name) {
+
+	// Keep nodes which have the pool label (added in GSK 1.31)
+	if _, found := labelMap[expectedPoolLabel]; found {
 		return true
+	}
+
+	// Here the server is part of this cluster but not of this pool.
+	// For backwards compatibility it could be that this cluster does not (yet) have the newly introduced
+	// "#gsk-pool#" label. We want to handle that.
+	// If the server has ANY pool label, we assume it correctly does not belong to this node group.
+	// If the server does not have ANY pool label, it may have not yet been labeled after the upgrade.
+	// In the last case, we match based on the server name.
+	if !containsPoolLabel {
+		// keep nodes whose name indicates they belong to this node group
+		return strings.Contains(server.Properties.Name, n.name)
 	}
 
 	return false

--- a/cluster-autoscaler/cloudprovider/gridscale/gridscale_node_group_test.go
+++ b/cluster-autoscaler/cloudprovider/gridscale/gridscale_node_group_test.go
@@ -70,6 +70,27 @@ func TestNodeGroup_Nodes(t *testing.T) {
 		require.Len(t, nodes, 0)
 	})
 
+	t.Run("does not return the master server", func(t *testing.T) {
+		setup()
+
+		client.GetServerListFunc = func(ctx context.Context) ([]gsclient.Server, error) {
+			return []gsclient.Server{
+				{
+					Properties: gsclient.ServerProperties{
+						Name: "test-cluster-master-0",
+						Labels: []string{
+							"#gsk#12345",
+						},
+					},
+				},
+			}, nil
+		}
+
+		nodes, err := group.Nodes()
+		require.NoError(t, err)
+		require.Len(t, nodes, 0)
+	})
+
 	t.Run("returns error if client returns an error", func(t *testing.T) {
 		setup()
 
@@ -93,6 +114,7 @@ func TestNodeGroup_Nodes(t *testing.T) {
 						Name: "some-other-cluster-node-pool-dev-0",
 						Labels: []string{
 							"#gsk#12345",
+							"#gsk-pool#pool-dev",
 						},
 					},
 				},
@@ -118,30 +140,33 @@ func TestNodeGroup_Nodes(t *testing.T) {
 
 		client.GetServerListFunc = func(ctx context.Context) ([]gsclient.Server, error) {
 			return []gsclient.Server{
-				// Server which belongs to another cluster
+				// Server which belongs to another cluster but with the same pool name
 				{
 					Properties: gsclient.ServerProperties{
 						Name: "some-other-cluster-node-pool-dev-0",
 						Labels: []string{
 							"#gsk#12345",
+							"#gsk-pool#pool-dev",
 						},
 					},
 				},
-				// Server which belongs to this cluster
+				// Server which belongs to this cluster and the dev pool
 				{
 					Properties: gsclient.ServerProperties{
 						Name: "my-cluster-node-pool-dev-0",
 						Labels: []string{
 							fmt.Sprintf("#gsk#%s", clusterID),
+							"#gsk-pool#pool-dev",
 						},
 					},
 				},
-				// Server which belongs to this cluster
+				// Server which belongs to this cluster and the dev pool
 				{
 					Properties: gsclient.ServerProperties{
 						Name: "my-cluster-node-pool-dev-1",
 						Labels: []string{
 							fmt.Sprintf("#gsk#%s", clusterID),
+							"#gsk-pool#pool-dev",
 						},
 					},
 				},
@@ -151,6 +176,7 @@ func TestNodeGroup_Nodes(t *testing.T) {
 						Name: "my-cluster-node-pool-prod-1",
 						Labels: []string{
 							fmt.Sprintf("#gsk#%s", clusterID),
+							"#gsk-pool#pool-prod",
 						},
 					},
 				},
@@ -163,6 +189,43 @@ func TestNodeGroup_Nodes(t *testing.T) {
 	})
 
 	t.Run("returns nodes which belongs to this cluster and node pool even on weired node pool names", func(t *testing.T) {
+		setup()
+
+		// This test assumes we have 2 pools named "pool0" and "pool01", which could be used
+		// by users.
+		group.name = "pool0"
+
+		client.GetServerListFunc = func(ctx context.Context) ([]gsclient.Server, error) {
+			return []gsclient.Server{
+				// Server which belongs to pool0
+				{
+					Properties: gsclient.ServerProperties{
+						Name: "my-cluster-node-pool0-0",
+						Labels: []string{
+							fmt.Sprintf("#gsk#%s", clusterID),
+							"#gsk-pool#pool0",
+						},
+					},
+				},
+				// Server which belongs to pool1
+				{
+					Properties: gsclient.ServerProperties{
+						Name: "my-cluster-node-pool01-0",
+						Labels: []string{
+							fmt.Sprintf("#gsk#%s", clusterID),
+							"#gsk-pool#pool01",
+						},
+					},
+				},
+			}, nil
+		}
+
+		nodes, err := group.Nodes()
+		require.NoError(t, err)
+		assert.Len(t, nodes, 1)
+	})
+
+	t.Run("returns nodes based on server name if no pool name is set", func(t *testing.T) {
 		setup()
 
 		// This test assumes we have 2 pools named "pool0" and "pool01", which could be used
@@ -194,6 +257,10 @@ func TestNodeGroup_Nodes(t *testing.T) {
 
 		nodes, err := group.Nodes()
 		require.NoError(t, err)
-		assert.Len(t, nodes, 1)
+
+		// Why 2 nodes? Because the implementation will fallback to matching servers based on their name.
+		// This was the logic used before the #gsk-pool# label was introduced. For compatibility reasons
+		// we keep this behavior, if a server does not have that label yet.
+		assert.Len(t, nodes, 2)
 	})
 }


### PR DESCRIPTION
The tests (which have been extended a bit) show which bug this PR fixes.

This fix is possible now that GSK 1.31 added a server label that can be used for a precise server selection, without the previous edge case. (see [release notes](https://my.gridscale.io/product-documentation/cloud-computing/products/paas/kubernetes/release-notes/introduction/#1319-gs0-released-2025-05-26))